### PR TITLE
Changed tokenizer to accept digits that start with the deciaml separator

### DIFF
--- a/src/main/java/de/congrace/exp4j/Tokenizer.java
+++ b/src/main/java/de/congrace/exp4j/Tokenizer.java
@@ -64,7 +64,7 @@ class Tokenizer {
 			char c = chars[i];
 			if (c == ' ')
 				continue;
-			if (Character.isDigit(c)) {
+			if (isDigitOrDecimalSeparator(c)) {
 				final StringBuilder valueBuilder = new StringBuilder(1);
 				// handle the numbers of the expression
 				valueBuilder.append(c);

--- a/src/test/java/de/congrace/exp4j/AllTests.java
+++ b/src/test/java/de/congrace/exp4j/AllTests.java
@@ -1,0 +1,13 @@
+package de.congrace.exp4j;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+@RunWith(Suite.class)
+@SuiteClasses({ ConcurrentExpressionBuilderTest.class,
+		ExpressionBuilderTest.class, ExpressionUtilTest.class,
+		RPNConverterTest.class, TokenizerTest.class })
+public class AllTests {
+
+}

--- a/src/test/java/de/congrace/exp4j/ExpressionBuilderTest.java
+++ b/src/test/java/de/congrace/exp4j/ExpressionBuilderTest.java
@@ -554,6 +554,14 @@ public class ExpressionBuilderTest {
 		double result = calc.calculate();
 		assertTrue(result == Math.log(Math.sin(varX)));
 	}
+	
+	@Test
+	public void testExpressionBuilder9() throws Exception {
+		double delta = .01;
+		assertEquals(.20, new ExpressionBuilder(".10+.10").build().calculate(), delta);
+		assertEquals(200, new ExpressionBuilder("1000 * (.10+.10) ").build().calculate(), delta);
+		assertEquals(.02, new ExpressionBuilder("(.10+.10)*.1").build().calculate(), delta);
+	}
 
 	@Test(expected = UnparsableExpressionException.class)
 	public void testSameName() throws Exception {


### PR DESCRIPTION
Hello,

I use exp4j for very simple but sometimes long equations where the values can be expressed as .002 or .1, etc. Currently the Tokenizer doesn't recognise these as numbers and throws an UnparsableExpressionException exception.

This push request adds this ability and tests cases for it, I have also added a test suite to test all test cases in one go.
