### PR TITLE
Fix broken functions validation

### DIFF
--- a/src/main/java/net/objecthunter/exp4j/Expression.java
+++ b/src/main/java/net/objecthunter/exp4j/Expression.java
@@ -91,8 +91,12 @@ public class Expression {
                     break;
                 case Token.TOKEN_FUNCTION:
                     final Function func = ((FunctionToken) tok).getFunction();
-                    if (func.getNumArguments() > count) {
+                    final int argsNum = func.getNumArguments(); 
+                    if (argsNum > count) {
                         errors.add("Not enough arguments for '" + func.getName() + "'");
+                    }
+                    if (argsNum > 1) {
+                        count -= argsNum - 1;
                     }
                     break;
                 case Token.TOKEN_OPERATOR:

--- a/src/test/java/net/objecthunter/exp4j/ExpressionValidateTest.java
+++ b/src/test/java/net/objecthunter/exp4j/ExpressionValidateTest.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright 2014 Bartosz Firyn
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.objecthunter.exp4j;
+
+import net.objecthunter.exp4j.function.Function;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class ExpressionValidateTest {
+
+	/**
+	 * Dummy function with 2 arguments.
+	 */
+	Function beta = new Function("beta", 2) {
+
+		@Override
+		public double apply(double... args) {
+			return args[1] - args[0];
+		}
+	};
+
+	/**
+	 * Dummy function with 3 arguments.
+	 */
+	Function gamma = new Function("gamma", 3) {
+
+		@Override
+		public double apply(double... args) {
+			return args[0] * args[1] / args[2];
+		}
+	};
+
+	/**
+	 * Dummy function with 7 arguments.
+	 */
+	Function eta = new Function("eta", 7) {
+
+		@Override
+		public double apply(double... args) {
+			double eta = 0;
+			for (double a : args) {
+				eta += a;
+			}
+			return eta;
+		}
+	};
+
+	// valid scenarios
+
+	@Test
+	public void testValidateNumber() throws Exception {
+		Expression exp = new ExpressionBuilder("1")
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateNumberPositive() throws Exception {
+		Expression exp = new ExpressionBuilder("+1")
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateNumberNegative() throws Exception {
+		Expression exp = new ExpressionBuilder("-1")
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateOperator() throws Exception {
+		Expression exp = new ExpressionBuilder("x + 1 + 2")
+			.variable("x")
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunction() throws Exception {
+		Expression exp = new ExpressionBuilder("sin(x)")
+			.variable("x")
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionPositive() throws Exception {
+		Expression exp = new ExpressionBuilder("+sin(x)")
+			.variable("x")
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionNegative() throws Exception {
+		Expression exp = new ExpressionBuilder("-sin(x)")
+			.variable("x")
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionAndOperator() throws Exception {
+		Expression exp = new ExpressionBuilder("sin(x + 1 + 2)")
+			.variable("x")
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionWithTwoArguments() throws Exception {
+		Expression exp = new ExpressionBuilder("beta(x, y)")
+			.variables("x", "y")
+			.functions(beta)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionWithTwoArgumentsAndOperator() throws Exception {
+		Expression exp = new ExpressionBuilder("beta(x, y + 1)")
+			.variables("x", "y")
+			.functions(beta)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionWithThreeArguments() throws Exception {
+		Expression exp = new ExpressionBuilder("gamma(x, y, z)")
+			.variables("x", "y", "z")
+			.functions(gamma)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionWithThreeArgumentsAndOperator() throws Exception {
+		Expression exp = new ExpressionBuilder("gamma(x, y, z + 1)")
+			.variables("x", "y", "z")
+			.functions(gamma)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionWithTwoAndThreeArguments() throws Exception {
+		Expression exp = new ExpressionBuilder("gamma(x, beta(y, h), z)")
+			.variables("x", "y", "z", "h")
+			.functions(gamma, beta)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionWithTwoAndThreeArgumentsAndOperator() throws Exception {
+		Expression exp = new ExpressionBuilder("gamma(x, beta(y, h), z + 1)")
+			.variables("x", "y", "z", "h")
+			.functions(gamma, beta)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionWithTwoAndThreeArgumentsAndMultipleOperator() throws Exception {
+		Expression exp = new ExpressionBuilder("gamma(x * 2 / 4, beta(y, h + 1 + 2), z + 1 + 2 + 3 + 4)")
+			.variables("x", "y", "z", "h")
+			.functions(gamma, beta)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionWithSevenArguments() throws Exception {
+		Expression exp = new ExpressionBuilder("eta(1, 2, 3, 4, 5, 6, 7)")
+			.functions(eta)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	@Test
+	public void testValidateFunctionWithSevenArgumentsAndoperator() throws Exception {
+		Expression exp = new ExpressionBuilder("eta(1, 2, 3, 4, 5, 6, 7) * 2 * 3 * 4")
+			.functions(eta)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertTrue(result.isValid());
+	}
+
+	// invalid scenarios
+
+	@Test
+	public void testValidateInvalidFunction() throws Exception {
+		Expression exp = new ExpressionBuilder("sin()")
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertFalse(result.isValid());
+	}
+
+	@Test
+	public void testValidateInvalidOperand() throws Exception {
+		Expression exp = new ExpressionBuilder("1 + ")
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertFalse(result.isValid());
+	}
+
+	@Test
+	public void testValidateInvalidFunctionWithTooFewArguments() throws Exception {
+		Expression exp = new ExpressionBuilder("beta(1)")
+			.functions(beta)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertFalse(result.isValid());
+	}
+
+	@Test
+	public void testValidateInvalidFunctionWithTooFewArgumentsAndOperands() throws Exception {
+		Expression exp = new ExpressionBuilder("beta(1 + )")
+			.functions(beta)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertFalse(result.isValid());
+	}
+
+	@Test
+	public void testValidateInvalidFunctionWithManyArguments() throws Exception {
+		Expression exp = new ExpressionBuilder("beta(1, 2, 3)")
+			.functions(beta)
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertFalse(result.isValid());
+	}
+
+	@Test
+	public void testValidateInvalidOperator() throws Exception {
+		Expression exp = new ExpressionBuilder("+")
+			.build();
+		ValidationResult result = exp.validate(false);
+		Assert.assertFalse(result.isValid());
+	}
+
+}


### PR DESCRIPTION
Hi @fasseg,

When working with validation feature of exp4j I found out that it does not work properly when one use own functions which takes more than one argument. Assume scenario as below.

Let ```beta``` be the function which takes two arguments:

```java
Function beta = new Function("beta", 2) {

	@Override
	public double apply(double... args) {
		return args[1] - args[0];
	}
};
```

And assume very simple, obviously valid expression which takes two variables:

```plain
beta(x, y)
```

When one call ```validate()``` such as:

```java
boolean result = new ExpressionBuilder("beta(x, y)")
	.variables("x", "y")
	.functions(beta)
	.build()
	.validate(false)
	.isValid();
```

The ```result``` will be ```false```, which is wrong...

This commit is to address this issue. Together with a code I committed small unit test which can be used to verify my fix.