### PR TITLE
Allowing an Expression to be copied

### DIFF
--- a/src/main/java/net/objecthunter/exp4j/Expression.java
+++ b/src/main/java/net/objecthunter/exp4j/Expression.java
@@ -39,6 +39,18 @@ public class Expression {
         vars.put("e", Math.E);
         return vars;
     }
+    
+    /**
+     * Creates a new expression that is a copy of the existing one.
+     * 
+     * @param existing the expression to copy
+     */
+    public Expression(Expression existing) {
+    	this.tokens = existing.tokens;
+    	this.variables = new HashMap<String,Double>();
+    	this.variables.putAll(existing.variables);
+    	this.userFunctionNames = new HashSet<String>(existing.userFunctionNames);
+    }
 
     Expression(final Token[] tokens) {
         this.tokens = tokens;

--- a/src/main/java/net/objecthunter/exp4j/Expression.java
+++ b/src/main/java/net/objecthunter/exp4j/Expression.java
@@ -45,7 +45,7 @@ public class Expression {
      * 
      * @param existing the expression to copy
      */
-    public Expression(Expression existing) {
+    public Expression(final Expression existing) {
     	this.tokens = Arrays.copyOf(existing.tokens, existing.tokens.length);
     	this.variables = new HashMap<String,Double>();
     	this.variables.putAll(existing.variables);

--- a/src/main/java/net/objecthunter/exp4j/Expression.java
+++ b/src/main/java/net/objecthunter/exp4j/Expression.java
@@ -46,7 +46,7 @@ public class Expression {
      * @param existing the expression to copy
      */
     public Expression(Expression existing) {
-    	this.tokens = existing.tokens;
+    	this.tokens = Arrays.copyOf(existing.tokens, existing.tokens.length);
     	this.variables = new HashMap<String,Double>();
     	this.variables.putAll(existing.variables);
     	this.userFunctionNames = new HashSet<String>(existing.userFunctionNames);


### PR DESCRIPTION
It's often useful to be able to copy an existing expression, without having to reparse the underlying string. The constructor creates a new expression from an existing one. Its simply makes a copy of its tokens, variables and functions.  
In multithreaded settings, one can for instance use this function to efficiently copy a expression, assign its variables to particular values, and evaluate the result.