### PR TITLE
add Integer operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>verify</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>

--- a/src/main/java/net/objecthunter/exp4j/Expression.java
+++ b/src/main/java/net/objecthunter/exp4j/Expression.java
@@ -216,14 +216,14 @@ public class Expression {
     }
 
     public Number evaluateTypeSave() {
-        final ArrayStack output = new ArrayStack();
+        final Deque<Number> output = new ArrayDeque<Number>();
         for (int i = 0; i < tokens.length; i++) {
             Token t = tokens[i];
             if (t.getType() == Token.TOKEN_NUMBER) {
                 output.push(((NumberToken) t).getValue());
             } else if (t.getType() == Token.TOKEN_VARIABLE) {
                 final String name = ((VariableToken) t).getName();
-                final Double value = (Double) this.variables.get(name);
+                final Number value = this.variables.get(name);
                 if (value == null) {
                     throw new IllegalArgumentException("No value has been set for the setVariable '" + name + "'.");
                 }
@@ -235,13 +235,13 @@ public class Expression {
                 }
                 if (op.getOperator().getNumOperands() == 2) {
                     /* pop the operands and push the result of the operation */
-                    double rightArg = output.pop();
-                    double leftArg = output.pop();
-                    output.push(op.getOperator().apply(leftArg, rightArg));
+                    Number rightArg = output.pop();
+                    Number leftArg = output.pop();
+                    output.push(op.getOperator().applyTypeSave(leftArg, rightArg));
                 } else if (op.getOperator().getNumOperands() == 1) {
                     /* pop the operand and push the result of the operation */
-                    double arg = output.pop();
-                    output.push(op.getOperator().apply(arg));
+                    Number arg = output.pop();
+                    output.push(op.getOperator().applyTypeSave(arg));
                 }
             } else if (t.getType() == Token.TOKEN_FUNCTION) {
                 FunctionToken func = (FunctionToken) t;
@@ -250,11 +250,11 @@ public class Expression {
                     throw new IllegalArgumentException("Invalid number of arguments available for '" + func.getFunction().getName() + "' function");
                 }
                 /* collect the arguments from the stack */
-                double[] args = new double[numArguments];
+                Number[] args = new Number[numArguments];
                 for (int j = numArguments - 1; j >= 0; j--) {
                     args[j] = output.pop();
                 }
-                output.push(func.getFunction().apply(args));
+                output.push(func.getFunction().applyTypeSave(args));
             }
         }
         if (output.size() > 1) {

--- a/src/main/java/net/objecthunter/exp4j/Expression.java
+++ b/src/main/java/net/objecthunter/exp4j/Expression.java
@@ -172,7 +172,7 @@ public class Expression {
         for (int i = 0; i < tokens.length; i++) {
             Token t = tokens[i];
             if (t.getType() == Token.TOKEN_NUMBER) {
-                output.push(((NumberToken) t).getValue());
+                output.push(((NumberToken) t).getValue().doubleValue());
             } else if (t.getType() == Token.TOKEN_VARIABLE) {
                 final String name = ((VariableToken) t).getName();
                 final Double value = (Double)this.variables.get(name);

--- a/src/main/java/net/objecthunter/exp4j/Expression.java
+++ b/src/main/java/net/objecthunter/exp4j/Expression.java
@@ -181,32 +181,32 @@ public class Expression {
                 }
                 output.push(value);
             } else if (t.getType() == Token.TOKEN_OPERATOR) {
-                OperatorToken op = (OperatorToken) t;
-                if (output.size() < op.getOperator().getNumOperands()) {
-                    throw new IllegalArgumentException("Invalid number of operands available for '" + op.getOperator().getSymbol() + "' operator");
+                Operator op = ((OperatorToken) t).getOperator();
+                if (output.size() < op.getNumOperands()) {
+                    throw new IllegalArgumentException("Invalid number of operands available for '" + op.getSymbol() + "' operator");
                 }
-                if (op.getOperator().getNumOperands() == 2) {
+                if (op.getNumOperands() == 2) {
                     /* pop the operands and push the result of the operation */
                     double rightArg = output.pop();
                     double leftArg = output.pop();
-                    output.push(op.getOperator().apply(leftArg, rightArg));
-                } else if (op.getOperator().getNumOperands() == 1) {
+                    output.push(op.apply(leftArg, rightArg));
+                } else if (op.getNumOperands() == 1) {
                     /* pop the operand and push the result of the operation */
                     double arg = output.pop();
-                    output.push(op.getOperator().apply(arg));
+                    output.push(op.apply(arg));
                 }
             } else if (t.getType() == Token.TOKEN_FUNCTION) {
-                FunctionToken func = (FunctionToken) t;
-                final int numArguments = func.getFunction().getNumArguments();
+                Function func = ((FunctionToken) t).getFunction();
+                final int numArguments = func.getNumArguments();
                 if (output.size() < numArguments) {
-                    throw new IllegalArgumentException("Invalid number of arguments available for '" + func.getFunction().getName() + "' function");
+                    throw new IllegalArgumentException("Invalid number of arguments available for '" + func.getName() + "' function");
                 }
                 /* collect the arguments from the stack */
                 double[] args = new double[numArguments];
                 for (int j = numArguments - 1; j >= 0; j--) {
                     args[j] = output.pop();
                 }
-                output.push(func.getFunction().apply(args));
+                output.push(func.apply(args));
             }
         }
         if (output.size() > 1) {
@@ -229,32 +229,32 @@ public class Expression {
                 }
                 output.push(value);
             } else if (t.getType() == Token.TOKEN_OPERATOR) {
-                OperatorToken op = (OperatorToken) t;
-                if (output.size() < op.getOperator().getNumOperands()) {
-                    throw new IllegalArgumentException("Invalid number of operands available for '" + op.getOperator().getSymbol() + "' operator");
+                Operator op = ((OperatorToken) t).getOperator();
+                if (output.size() < op.getNumOperands()) {
+                    throw new IllegalArgumentException("Invalid number of operands available for '" + op.getSymbol() + "' operator");
                 }
-                if (op.getOperator().getNumOperands() == 2) {
+                if (op.getNumOperands() == 2) {
                     /* pop the operands and push the result of the operation */
                     Number rightArg = output.pop();
                     Number leftArg = output.pop();
-                    output.push(op.getOperator().applyTypeSave(leftArg, rightArg));
-                } else if (op.getOperator().getNumOperands() == 1) {
+                    output.push(op.applyTypeSave(leftArg, rightArg));
+                } else if (op.getNumOperands() == 1) {
                     /* pop the operand and push the result of the operation */
                     Number arg = output.pop();
-                    output.push(op.getOperator().applyTypeSave(arg));
+                    output.push(op.applyTypeSave(arg));
                 }
             } else if (t.getType() == Token.TOKEN_FUNCTION) {
-                FunctionToken func = (FunctionToken) t;
-                final int numArguments = func.getFunction().getNumArguments();
+                Function func = ((FunctionToken) t).getFunction();
+                final int numArguments = func.getNumArguments();
                 if (output.size() < numArguments) {
-                    throw new IllegalArgumentException("Invalid number of arguments available for '" + func.getFunction().getName() + "' function");
+                    throw new IllegalArgumentException("Invalid number of arguments available for '" + func.getName() + "' function");
                 }
                 /* collect the arguments from the stack */
                 Number[] args = new Number[numArguments];
                 for (int j = numArguments - 1; j >= 0; j--) {
                     args[j] = output.pop();
                 }
-                output.push(func.getFunction().applyTypeSave(args));
+                output.push(func.applyTypeSave(args));
             }
         }
         if (output.size() > 1) {

--- a/src/main/java/net/objecthunter/exp4j/TypeUtil.java
+++ b/src/main/java/net/objecthunter/exp4j/TypeUtil.java
@@ -30,6 +30,14 @@ public class TypeUtil {
         return true;
     }
 
+    public static Number parseConstant(String value) {
+        try {
+            return Long.valueOf(value);
+        } catch (NumberFormatException nfe) {
+            return Double.valueOf(value);
+        }
+    }
+
     public static double[] toDouble(Number ... values) {
         double[] result = new double[values.length];
         int i = 0;

--- a/src/main/java/net/objecthunter/exp4j/TypeUtil.java
+++ b/src/main/java/net/objecthunter/exp4j/TypeUtil.java
@@ -1,0 +1,31 @@
+/* 
+* Copyright 2015 Holger Klene
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License. 
+*/
+package net.objecthunter.exp4j;
+
+import java.util.Map;
+import java.util.Map.Entry;
+
+public class TypeUtil {
+
+    public static void toDouble(Map<?, Number> values) {
+        for (Entry<?, Number> entry : values.entrySet()) {
+            if (!(entry.getValue() instanceof Double)) {
+                entry.setValue(entry.getValue().doubleValue());
+            }
+        }
+    }
+
+}

--- a/src/main/java/net/objecthunter/exp4j/TypeUtil.java
+++ b/src/main/java/net/objecthunter/exp4j/TypeUtil.java
@@ -15,10 +15,29 @@
 */
 package net.objecthunter.exp4j;
 
+import java.math.BigInteger;
 import java.util.Map;
 import java.util.Map.Entry;
 
 public class TypeUtil {
+
+    public static boolean isAllIntegral(Number ... value) {
+        for (Number v : value) {
+            if (!(v instanceof Long || v instanceof Integer || v instanceof BigInteger)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static double[] toDouble(Number ... values) {
+        double[] result = new double[values.length];
+        int i = 0;
+        for (Number v : values) {
+            result[i++] = v.doubleValue();
+        }
+        return result;
+    }
 
     public static void toDouble(Map<?, Number> values) {
         for (Entry<?, Number> entry : values.entrySet()) {

--- a/src/main/java/net/objecthunter/exp4j/TypeUtil.java
+++ b/src/main/java/net/objecthunter/exp4j/TypeUtil.java
@@ -31,9 +31,18 @@ public class TypeUtil {
     }
 
     public static Number parseConstant(String value) {
+        final String v = value.toLowerCase();
+        final boolean hex = v.startsWith("0x");
         try {
+            if (hex) {
+                return Long.valueOf(value.substring(2), 16);
+            }
             return Long.valueOf(value);
         } catch (NumberFormatException nfe) {
+            if (hex && -1 == v.lastIndexOf('p')) {
+                // add binary exponent declaration if missing
+                return Double.valueOf(value + "p0");
+            }
             return Double.valueOf(value);
         }
     }

--- a/src/main/java/net/objecthunter/exp4j/function/Function.java
+++ b/src/main/java/net/objecthunter/exp4j/function/Function.java
@@ -16,6 +16,8 @@
 
 package net.objecthunter.exp4j.function;
 
+import net.objecthunter.exp4j.TypeUtil;
+
 /**
  * A class representing a Function which can be used in an expression
  */
@@ -78,6 +80,14 @@ public abstract class Function {
      * @return the result of the function evaluation
      */
     public abstract double apply(double... args);
+
+    public Number applyTypeSave(Number... args) {
+        double result = apply(TypeUtil.toDouble(args));
+        if (TypeUtil.isAllIntegral(args)) {
+            return (long)result;
+        }
+        return result;
+    }
 
     /**
      * Get the set of characters which are allowed for use in Function names.

--- a/src/main/java/net/objecthunter/exp4j/function/Function.java
+++ b/src/main/java/net/objecthunter/exp4j/function/Function.java
@@ -131,4 +131,9 @@ public abstract class Function {
         }
         return true;
     }
+
+    public String toString() {
+        return String.format("%s-Function(%d)", getName(), getNumArguments());
+    }
+
 }

--- a/src/main/java/net/objecthunter/exp4j/operator/Operator.java
+++ b/src/main/java/net/objecthunter/exp4j/operator/Operator.java
@@ -15,6 +15,8 @@
 */
 package net.objecthunter.exp4j.operator;
 
+import net.objecthunter.exp4j.TypeUtil;
+
 /**
  * Class representing operators that can be used in an expression
  */
@@ -115,6 +117,19 @@ public abstract class Operator {
      */
     public abstract double apply(double ... args);
 
+    /**
+     * Apply the operation on the given operands
+     * @param args the operands for the operation
+     * @return the calculated result of the operation
+     */
+    public Number applyTypeSave(Number ... args) {
+        double result = apply(TypeUtil.toDouble(args));
+        if (TypeUtil.isAllIntegral(args)) {
+            return (long)result;
+        }
+        return result;
+    }
+    
     /**
      * Get the operator symbol
      * @return the symbol

--- a/src/main/java/net/objecthunter/exp4j/operator/Operator.java
+++ b/src/main/java/net/objecthunter/exp4j/operator/Operator.java
@@ -145,4 +145,11 @@ public abstract class Operator {
     public int getNumOperands() {
         return numOperands;
     }
+
+    @Override
+    public String toString() {
+        return String.format("%s-Operator(l=%s, %d, %d)",
+                getSymbol(), isLeftAssociative() ? 'l' : 'r', getNumOperands(), getPrecedence());
+    }
+
 }

--- a/src/main/java/net/objecthunter/exp4j/tokenizer/NumberToken.java
+++ b/src/main/java/net/objecthunter/exp4j/tokenizer/NumberToken.java
@@ -41,4 +41,9 @@ public final class NumberToken extends Token {
     public double getValue() {
         return value;
     }
+
+    public String toString() {
+        return String.format("const %s", getValue());
+    }
+
 }

--- a/src/main/java/net/objecthunter/exp4j/tokenizer/NumberToken.java
+++ b/src/main/java/net/objecthunter/exp4j/tokenizer/NumberToken.java
@@ -15,30 +15,36 @@
 */
 package net.objecthunter.exp4j.tokenizer;
 
+import net.objecthunter.exp4j.TypeUtil;
+
 /**
  * Represents a number in the expression
  */
 public final class NumberToken extends Token {
-    private final double value;
+    private final Number value;
 
     /**
      * Create a new instance
      * @param value the value of the number
      */
-    public NumberToken(double value) {
+    public NumberToken(Number value) {
         super(TOKEN_NUMBER);
         this.value = value;
     }
 
+    NumberToken(String value) {
+        this(TypeUtil.parseConstant(value));
+    }
+
     NumberToken(final char[] expression, final int offset, final int len) {
-        this(Double.parseDouble(String.valueOf(expression, offset, len)));
+        this(String.valueOf(expression, offset, len));
     }
 
     /**
      * Get the value of the number
      * @return the value
      */
-    public double getValue() {
+    public Number getValue() {
         return value;
     }
 

--- a/src/main/java/net/objecthunter/exp4j/tokenizer/Tokenizer.java
+++ b/src/main/java/net/objecthunter/exp4j/tokenizer/Tokenizer.java
@@ -225,7 +225,7 @@ public class Tokenizer {
         int len = 1;
         this.pos++;
         if (isEndOfExpression(offset + len)) {
-            lastToken = new NumberToken(Double.parseDouble(String.valueOf(firstChar)));
+            lastToken = new NumberToken(Character.digit(firstChar, 10));
             return lastToken;
         }
         while (!isEndOfExpression(offset + len) &&

--- a/src/main/java/net/objecthunter/exp4j/tokenizer/VariableToken.java
+++ b/src/main/java/net/objecthunter/exp4j/tokenizer/VariableToken.java
@@ -37,4 +37,10 @@ public class VariableToken extends Token {
         super(TOKEN_VARIABLE);
         this.name = name;
     }
+
+    @Override
+    public String toString() {
+        return String.format("%s-Variable", getName());
+    }
+
 }

--- a/src/test/java/net/objecthunter/exp4j/PerformanceTest.java
+++ b/src/test/java/net/objecthunter/exp4j/PerformanceTest.java
@@ -44,13 +44,19 @@ public class PerformanceTest {
         System.out.print(sb.toString());
         sb.setLength(0);
 
-         int db = benchDouble();
+        int db = benchDouble();
         double dbRate = (double) db / (double) BENCH_TIME;
-        fmt.format("| %-22s | %25.2f | %22.2f %% |%n", "exp4j", dbRate, dbRate * 100 / mathRate);
+        fmt.format("| %-22s | %25.2f | %22.2f %% |%n", "exp4j (double only)", dbRate, dbRate * 100 / mathRate);
         System.out.print(sb.toString());
         sb.setLength(0);
 
-         int js = benchJavaScript();
+        int ts = benchTypeSave();
+        double tsRate = (double) ts / (double) BENCH_TIME;
+        fmt.format("| %-22s | %25.2f | %22.2f %% |%n", "exp4j (int&double mix)", tsRate, tsRate * 100 / mathRate);
+        System.out.print(sb.toString());
+        sb.setLength(0);
+
+        int js = benchJavaScript();
         double jsRate = (double) js / (double) BENCH_TIME;
         fmt.format("| %-22s | %25.2f | %22.2f %% |%n", "JSR-223 (Java Script)", jsRate, jsRate * 100 / mathRate);
         fmt.format("+------------------------+---------------------------+--------------------------+%n");
@@ -70,6 +76,25 @@ public class PerformanceTest {
             expression.setVariable("x", rnd.nextDouble());
             expression.setVariable("y", rnd.nextDouble());
             val = expression.evaluate();
+            count++;
+        }
+        double rate = count / timeout;
+        return count;
+    }
+
+    private int benchTypeSave() {
+        final Expression expression = new ExpressionBuilder(EXPRESSION)
+                .variables("x", "y")
+                .build();
+        double val;
+        Random rnd = new Random();
+        long timeout = BENCH_TIME;
+        long time = System.currentTimeMillis() + (1000 * timeout);
+        int count = 0;
+        while (time > System.currentTimeMillis()) {
+            expression.setVariable("x", rnd.nextLong());
+            expression.setVariable("y", rnd.nextDouble());
+            val = expression.evaluateTypeSave().doubleValue();
             count++;
         }
         double rate = count / timeout;

--- a/src/test/java/net/objecthunter/exp4j/TestUtil.java
+++ b/src/test/java/net/objecthunter/exp4j/TestUtil.java
@@ -53,7 +53,7 @@ public abstract class TestUtil {
 
     public static void assertNumberToken(Token tok, double v) {
         assertEquals(tok.getType(), Token.TOKEN_NUMBER);
-        Assert.assertEquals(v, ((NumberToken) tok).getValue(), 0d);
+        Assert.assertEquals(v, ((NumberToken) tok).getValue().doubleValue(), 0d);
     }
 
     public static void assertFunctionSeparatorToken(Token t) {

--- a/src/test/java/net/objecthunter/exp4j/tokenizer/TokenizerTest.java
+++ b/src/test/java/net/objecthunter/exp4j/tokenizer/TokenizerTest.java
@@ -19,6 +19,7 @@ import static net.objecthunter.exp4j.TestUtil.*;
 import static org.junit.Assert.*;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -551,4 +552,46 @@ public class TokenizerTest {
 
         assertFalse(tokenizer.hasNext());
     }
+
+    @Test
+    public void testTokenization23() throws Exception {
+        final Tokenizer tokenizer = new Tokenizer("0x123 + 0xABCD.1 - 0x00fe * 0x.2p2 - 0x", null, null,
+                Collections.singleton("x"));
+
+        assertTrue(tokenizer.hasNext());
+        assertNumberToken(tokenizer.nextToken(), 0x123);
+
+        assertTrue(tokenizer.hasNext());
+        assertOperatorToken(tokenizer.nextToken(), "+", 2, Operator.PRECEDENCE_ADDITION);
+
+        assertTrue(tokenizer.hasNext());
+        assertNumberToken(tokenizer.nextToken(), Double.parseDouble("0xABCD.1p0"));
+
+        assertTrue(tokenizer.hasNext());
+        assertOperatorToken(tokenizer.nextToken(), "-", 2, Operator.PRECEDENCE_SUBTRACTION);
+
+        assertTrue(tokenizer.hasNext());
+        assertNumberToken(tokenizer.nextToken(), 0xFE);
+
+        assertTrue(tokenizer.hasNext());
+        assertOperatorToken(tokenizer.nextToken(), "*", 2, Operator.PRECEDENCE_MULTIPLICATION);
+
+        assertTrue(tokenizer.hasNext());
+        assertNumberToken(tokenizer.nextToken(), Double.parseDouble("0x.2p2"));
+
+        assertTrue(tokenizer.hasNext());
+        assertOperatorToken(tokenizer.nextToken(), "-", 2, Operator.PRECEDENCE_SUBTRACTION);
+
+        assertTrue(tokenizer.hasNext());
+        assertNumberToken(tokenizer.nextToken(), 0);
+
+        assertTrue(tokenizer.hasNext());
+        assertOperatorToken(tokenizer.nextToken(), "*", 2, Operator.PRECEDENCE_MULTIPLICATION);
+
+        assertTrue(tokenizer.hasNext());
+        assertVariableToken(tokenizer.nextToken(), "x");
+
+        assertFalse(tokenizer.hasNext());
+    }
+
 }


### PR DESCRIPTION
Hello!

I've added a new Expression.evaluateTypeSave() method to the interface. Basically I want to support Integer mathematics: 3/2=1 != 1.5 as the result is cast back to integer. Effectively all Operators and all Functions are extended with applyTypeSave(Number...) that can determine the type of the result (Double or Long) by checking if the input parameters were integral (any of Integer, Long, BigInteger -> TypeUtil.isAllIntegral(Number...)).

So for example 5^2=pow(5,2)=25 != 25.0, but also 5^-1=pow(5,-1)=0 != 0.2 this might be somewhat unexpected, if you are used to java.lang.Math.pow(double, double) that always evaluates to a double. Same for sin(integer) will be in [-1, 0, 1]. Of course you get normal evaluation for 5^0.5=pow(5,0.5)=sqrt(5)=2.236 as one double parameter takes precedence to make the result evaluate to double. Compare to: 5^(1/2)=pow(5,1/2)=1

I've added the new evaluateTypeSave() to the performance test, but the results jump pretty much, as I am not alone on this machine, depending on the background load. Interchanging the order of pure double calculations and mixed integer evaluation shows, that the first is highly impacted by JIT-compilation, whereas the second profits massively.

Sensitive issues:

- The interface of Expression changed to add new methods and also updating parameter lists. This will be compatible with users of exp4j but will break subclasses of Expression, that try to override setVariables(Map).

- I delayed the sign step until maven phase install to not bother with setting up my own key, as I do not plan to publish this fork on maven central.

- There were toString() methods added to Operator, Function and others ... extremely handy when debugging.

- The new applyTypeSave(Number...) obviously relay to the original apply(double ...) thereby I was forced, to always create an additional new parameter-array-object compared to the original calculations. I wonder how intelligent the java-compiler got nowadays, that this didn't hit negatively on performance.

- Parsing constant values within the formula is done by trying to parse a Long first and only on Exception falling back to Double. I know Exception handling isn't supposed to be used for control flow. But I didn't want to reimplement the Long.valueOf(String). This is also a performance burden on the initial parse phase. But as you didn't run performance tests on the parsing itself, I deemed this acceptable. (see TypeUtil.parseConstant())

- Speaking of tests: the new evaluateTypeSave() is explicitly *not* a replacement, as it calculates different intermediate results: e.g. 1 / (1 / 2) will throw division by zero instead of returning 2, whereas 1 / (1 / 2.0) will give 2.0 and not 2. For fun I still made evaluate() to call evaluateTypeSave() and ran your tests, that passed 95% (15 fail of 286). Those cases mostly rely on integer constants in expressions to evaluate to double, as has been done to calculate the expected result but not explicitly written as e.g. 2.0 in the formula string.

- Though it is not a replacement, it could be considered duplicate code with the original evaluate(). I decided against trying to factor this out by lambda-expressions, as it first requires Java8 and second still would likely introduce a performance penalty.

Keen to read your comments and happy coding
Holger