### PR TITLE
Add ability to clear variables in expression

### DIFF
--- a/src/main/java/net/objecthunter/exp4j/Expression.java
+++ b/src/main/java/net/objecthunter/exp4j/Expression.java
@@ -77,12 +77,18 @@ public class Expression {
     }
 
     public Expression setVariables(Map<String, Double> variables) {
+    	this.variables.clear();
         for (Map.Entry<String, Double> v : variables.entrySet()) {
             this.setVariable(v.getKey(), v.getValue());
         }
         return this;
     }
 
+    public Expression clearVariables(){
+        this.variables.clear();
+        return this;
+    }
+    
     public ValidationResult validate(boolean checkVariablesSet) {
         final List<String> errors = new ArrayList<String>(0);
         if (checkVariablesSet) {

--- a/src/test/java/net/objecthunter/exp4j/ExpressionTest.java
+++ b/src/test/java/net/objecthunter/exp4j/ExpressionTest.java
@@ -27,6 +27,8 @@ import net.objecthunter.exp4j.tokenizer.Token;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -53,6 +55,42 @@ public class ExpressionTest {
         assertEquals(0d, exp.evaluate(), 0d);
     }
 
+    @Test
+    public void testClearVariables() {
+        ExpressionBuilder builder = new ExpressionBuilder("a + b");
+        builder.variable("a");
+        builder.variable("b");
+
+        Expression expression = builder.build();
+        Map<String, Double> values = new HashMap<String, Double>();
+        values.put("a", 1.0);
+        values.put("b", 2.0);
+        expression.setVariables(values);
+
+
+        double result = expression.evaluate();
+        assertEquals(3.0, result, 3.0-result);
+
+        expression.clearVariables();
+        try{
+                result = expression.evaluate();
+                assertEquals("should have failed here because there shouldn't be any values in the expression.", false, true);
+        }catch(Exception e){
+
+        }
+        Map<String, Double> emptyMap = new HashMap<String, Double>();
+        expression.setVariables(emptyMap);
+        try{
+                result = expression.evaluate();
+                assertEquals("should have failed here because there shouldn't be any values in the expression.", false, true);
+        }catch(Exception e){
+
+        }
+
+    }
+
+
+    
     @Test
     @Ignore
     // If Expression should be threads safe this test must pass


### PR DESCRIPTION
Hi,

I just wanted to contribute a very simple change.  I wanted to provide the client side to be able to clear the variables set or if a map is passed in to clear the old state.

I have a process that cycles  through a series of expressions against different maps with different variables and values.
eg:
expressions = {
expression 1: a + b
expression 2: x - y
}

I have a list of maps with different values:
maps = {
map1: a->1, b->2,
map2: x>5, y->2
}
expression1.setVariables(map1);
expression1.validate(true); will return a true, which is correct!
If immediately after I do expession1.setVariables(map2) this will also return a true, which is incorrect as map2 has variables x and y and not a and b.  It returns true because the expression has state with regards to the variables.

For the reason I mentioned above I suggest a clearing of the data.  I hope you find this contribution of some benefit to you.

Thanks,
Sajith
