### PR TITLE
Add possibility to extract missing variable/function name from exception

### DIFF
--- a/src/main/java/net/objecthunter/exp4j/tokenizer/Tokenizer.java
+++ b/src/main/java/net/objecthunter/exp4j/tokenizer/Tokenizer.java
@@ -159,7 +159,7 @@ public class Tokenizer {
             len++;
         }
         if (lastValidToken == null) {
-            throw new IllegalArgumentException("Unable to parse variable or function starting at pos " + pos + " in expression '" + new String(expression) + "'");
+            throw new UnknownFunctionOrVariableException(new String(expression), pos, len);
         }
         pos += lastValidLen;
         lastToken = lastValidToken;

--- a/src/main/java/net/objecthunter/exp4j/tokenizer/UnknownFunctionOrVariableException.java
+++ b/src/main/java/net/objecthunter/exp4j/tokenizer/UnknownFunctionOrVariableException.java
@@ -1,0 +1,64 @@
+package net.objecthunter.exp4j.tokenizer;
+
+/**
+ * This exception is being thrown whenever {@link Tokenizer} finds unknown function or variable.
+ *
+ * @author Bartosz Firyn (sarxos)
+ */
+public class UnknownFunctionOrVariableException extends IllegalArgumentException {
+
+	/**
+	 * Serial version UID.
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private final String message;
+	private final String expression;
+	private final String token;
+	private final int position;
+
+	public UnknownFunctionOrVariableException(String expression, int position, int length) {
+		this.expression = expression;
+		this.token = token(expression, position, length);
+		this.position = position;
+		this.message = "Unknown function or variable '" + token + "' at pos " + position + " in expression '" + expression + "'";
+	}
+
+	private static String token(String expression, int position, int length) {
+
+		int len = expression.length();
+		int end = position + length - 1;
+
+		if (len < end) {
+			end = len;
+		}
+
+		return expression.substring(position, end);
+	}
+
+	@Override
+	public String getMessage() {
+		return message;
+	}
+
+	/**
+	 * @return Expression which contains unknown function or variable
+	 */
+	public String getExpression() {
+		return expression;
+	}
+
+	/**
+	 * @return The name of unknown function or variable
+	 */
+	public String getToken() {
+		return token;
+	}
+
+	/**
+	 * @return The position of unknown function or variable
+	 */
+	public int getPosition() {
+		return position;
+	}
+}

--- a/src/test/java/net/objecthunter/exp4j/tokenizer/TokenizerUnknownTokenOrVariableTest.java
+++ b/src/test/java/net/objecthunter/exp4j/tokenizer/TokenizerUnknownTokenOrVariableTest.java
@@ -1,0 +1,94 @@
+package net.objecthunter.exp4j.tokenizer;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * This test is to check if {@link UnknownFunctionOrVariableException} generated when expression
+ * contains unknown function or variable contains necessary expected details.
+ *
+ * @author Bartosz Firyn (sarxos)
+ */
+public class TokenizerUnknownTokenOrVariableTest {
+
+	@Test(expected = UnknownFunctionOrVariableException.class)
+	public void testTokenizationOfUnknownVariable() throws Exception {
+		final Tokenizer tokenizer = new Tokenizer("3 + x", null, null, null);
+		while (tokenizer.hasNext()) {
+			tokenizer.nextToken();
+		}
+	}
+
+	@Test
+	public void testTokenizationOfUnknownVariable1Details() throws Exception {
+
+		final Tokenizer tokenizer = new Tokenizer("3 + x", null, null, null);
+		tokenizer.nextToken(); // 3
+		tokenizer.nextToken(); // +
+
+		try {
+			tokenizer.nextToken(); // x
+			Assert.fail("Variable 'x' should be unknown!");
+		} catch (UnknownFunctionOrVariableException e) {
+			Assert.assertEquals("x", e.getToken());
+			Assert.assertEquals(4, e.getPosition());
+			Assert.assertEquals("3 + x", e.getExpression());
+		}
+	}
+
+	@Test
+	public void testTokenizationOfUnknownVariable2Details() throws Exception {
+
+		final Tokenizer tokenizer = new Tokenizer("x + 3", null, null, null);
+
+		try {
+			tokenizer.nextToken(); // x
+			Assert.fail("Variable 'x' should be unknown!");
+		} catch (UnknownFunctionOrVariableException e) {
+			Assert.assertEquals("x", e.getToken());
+			Assert.assertEquals(0, e.getPosition());
+			Assert.assertEquals("x + 3", e.getExpression());
+		}
+	}
+
+	@Test(expected = UnknownFunctionOrVariableException.class)
+	public void testTokenizationOfUnknownFunction() throws Exception {
+		final Tokenizer tokenizer = new Tokenizer("3 + p(1)", null, null, null);
+		while (tokenizer.hasNext()) {
+			tokenizer.nextToken();
+		}
+	}
+
+	@Test
+	public void testTokenizationOfUnknownFunction1Details() throws Exception {
+
+		final Tokenizer tokenizer = new Tokenizer("3 + p(1)", null, null, null);
+		tokenizer.nextToken(); // 3
+		tokenizer.nextToken(); // +
+
+		try {
+			tokenizer.nextToken(); // p
+			Assert.fail("Function 'p' should be unknown!");
+		} catch (UnknownFunctionOrVariableException e) {
+			Assert.assertEquals("p", e.getToken());
+			Assert.assertEquals(4, e.getPosition());
+			Assert.assertEquals("3 + p(1)", e.getExpression());
+		}
+	}
+
+	@Test
+	public void testTokenizationOfUnknownFunction2Details() throws Exception {
+
+		final Tokenizer tokenizer = new Tokenizer("p(1) + 3", null, null, null);
+
+		try {
+			tokenizer.nextToken(); // p
+			Assert.fail("Function 'p' should be unknown!");
+		} catch (UnknownFunctionOrVariableException e) {
+			Assert.assertEquals("p", e.getToken());
+			Assert.assertEquals(0, e.getPosition());
+			Assert.assertEquals("p(1) + 3", e.getExpression());
+		}
+	}
+}


### PR DESCRIPTION
Hi @fasseg,

Lately I was hit by a need to extract missing variable/function name from expression when ```build()``` is invoked and user did not provide variable/function on the input. In previous implementation it caused exception which had some details, but not all I needed. This pull request is to address this case.

Example use case:

```java
public static void main(String[] args) {

	Set<String> variables = new LinkedHashSet<>();
	Expression exp = null;
	ExpressionBuilder x = new ExpressionBuilder("3 * sin(pi) - x + 2 / (y - 2) + z + p(1)");
	do {
		try {
			exp = x.build();
			break;
		} catch (UnknownFunctionOrVariableException ufe) {
			x.variable(ufe.getToken());
			variables.add(ufe.getToken());
			System.out.println(ufe.getMessage());
		}
	} while (true);

	System.out.println("Missing variables/functions are: " + variables);
}
```

The output is:

```plain
Unknown function or variable 'x' at pos 14 in expression '3 * sin(pi) - x + 2 / (y - 2) + z + p(1)'
Unknown function or variable 'y' at pos 23 in expression '3 * sin(pi) - x + 2 / (y - 2) + z + p(1)'
Unknown function or variable 'z' at pos 32 in expression '3 * sin(pi) - x + 2 / (y - 2) + z + p(1)'
Unknown function or variable 'p' at pos 36 in expression '3 * sin(pi) - x + 2 / (y - 2) + z + p(1)'
Missing variables/functions are: [x, y, z, p]
```

I added few test cases to cover this enhancement. To have backward compatibility with the previous releases I extended original ```IllegalArgumentException``` so all existing ```try/catch``` clauses may remain unmodified.

Take care!