### PR TITLE
Added a 'ExceptionOnMissingVariable' parameter to the equationbuilder.

### DIFF
--- a/src/main/java/net/objecthunter/exp4j/ExpressionBuilder.java
+++ b/src/main/java/net/objecthunter/exp4j/ExpressionBuilder.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Copyright 2014 Frank Asseg
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,8 @@ public class ExpressionBuilder {
     private final Set<String> variableNames;
 
     private boolean implicitMultiplication = true;
+
+	public boolean exceptionOnMissingVariables = true;
 
     /**
      * Create a new ExpressionBuilder instance and initialize it with a given expression string.
@@ -186,7 +188,7 @@ public class ExpressionBuilder {
             }
         }
         return new Expression(ShuntingYard.convertToRPN(this.expression, this.userFunctions, this.userOperators,
-                this.variableNames, this.implicitMultiplication), this.userFunctions.keySet());
+                this.variableNames, this.implicitMultiplication, this.exceptionOnMissingVariables), this.userFunctions.keySet());
     }
 
 }

--- a/src/main/java/net/objecthunter/exp4j/operator/Operator.java
+++ b/src/main/java/net/objecthunter/exp4j/operator/Operator.java
@@ -1,4 +1,4 @@
-/* 
+/*
 * Copyright 2014 Frank Asseg
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +11,7 @@
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
-* limitations under the License. 
+* limitations under the License.
 */
 package net.objecthunter.exp4j.operator;
 
@@ -55,7 +55,7 @@ public abstract class Operator {
     /**
      * The set of allowed operator chars
      */
-    public static final char[] ALLOWED_OPERATOR_CHARS = { '+', '-', '*', '/', '%', '^', '!', '#','§', '$', '&', ';', ':', '~', '<', '>', '|', '='};
+    public static final char[] ALLOWED_OPERATOR_CHARS = { '+', '-', '*', '/', '%', '^', '!', '#', '$', '&', ';', ':', '~', '<', '>', '|', '='};
 
     protected final int numOperands;
     protected final boolean leftAssociative;

--- a/src/main/java/net/objecthunter/exp4j/shuntingyard/ShuntingYard.java
+++ b/src/main/java/net/objecthunter/exp4j/shuntingyard/ShuntingYard.java
@@ -38,11 +38,11 @@ public class ShuntingYard {
      * @return a {@link net.objecthunter.exp4j.tokenizer.Token} array containing the result
      */
     public static Token[] convertToRPN(final String expression, final Map<String, Function> userFunctions,
-            final Map<String, Operator> userOperators, final Set<String> variableNames, final boolean implicitMultiplication){
+            final Map<String, Operator> userOperators, final Set<String> variableNames, final boolean implicitMultiplication, final boolean exceptionOnMissingVariable){
         final Stack<Token> stack = new Stack<Token>();
         final List<Token> output = new ArrayList<Token>();
 
-        final Tokenizer tokenizer = new Tokenizer(expression, userFunctions, userOperators, variableNames, implicitMultiplication);
+        final Tokenizer tokenizer = new Tokenizer(expression, userFunctions, userOperators, variableNames, implicitMultiplication, exceptionOnMissingVariable);
         while (tokenizer.hasNext()) {
             Token token = tokenizer.nextToken();
             switch (token.getType()) {

--- a/src/main/java/net/objecthunter/exp4j/tokenizer/Tokenizer.java
+++ b/src/main/java/net/objecthunter/exp4j/tokenizer/Tokenizer.java
@@ -11,7 +11,7 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  */
 package net.objecthunter.exp4j.tokenizer;
 
@@ -186,9 +186,7 @@ public class Tokenizer {
 				throw new UnknownFunctionOrVariableException(new String(expression), pos, len);
 			}
 			else {
-				if (isEndOfExpression(offset + len - 1)) {
-					len--;
-				}
+				len--;
 
 				String name = new String( expression, offset, len );
 

--- a/src/test/java/net/objecthunter/exp4j/shuntingyard/ShuntingYardTest.java
+++ b/src/test/java/net/objecthunter/exp4j/shuntingyard/ShuntingYardTest.java
@@ -32,7 +32,7 @@ public class ShuntingYardTest {
     @Test
     public void testShuntingYard1() throws Exception {
         String expression = "2+3";
-        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true);
+        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true, true);
         assertNumberToken(tokens[0], 2d);
         assertNumberToken(tokens[1], 3d);
         assertOperatorToken(tokens[2], "+", 2, Operator.PRECEDENCE_ADDITION);
@@ -41,7 +41,7 @@ public class ShuntingYardTest {
     @Test
     public void testShuntingYard2() throws Exception {
         String expression = "3*x";
-        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, new HashSet<String>(Arrays.asList("x")), true);
+        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, new HashSet<String>(Arrays.asList("x")), true, true);
         assertNumberToken(tokens[0], 3d);
         assertVariableToken(tokens[1], "x");
         assertOperatorToken(tokens[2], "*", 2, Operator.PRECEDENCE_MULTIPLICATION);
@@ -50,7 +50,7 @@ public class ShuntingYardTest {
     @Test
     public void testShuntingYard3() throws Exception {
         String expression = "-3";
-        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true);
+        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true, true);
         assertNumberToken(tokens[0], 3d);
         assertOperatorToken(tokens[1], "-", 1, Operator.PRECEDENCE_UNARY_MINUS);
     }
@@ -58,7 +58,7 @@ public class ShuntingYardTest {
     @Test
     public void testShuntingYard4() throws Exception {
         String expression = "-2^2";
-        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true);
+        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true, true);
         assertNumberToken(tokens[0], 2d);
         assertNumberToken(tokens[1], 2d);
         assertOperatorToken(tokens[2], "^", 2, Operator.PRECEDENCE_POWER);
@@ -68,7 +68,7 @@ public class ShuntingYardTest {
     @Test
     public void testShuntingYard5() throws Exception {
         String expression = "2^-2";
-        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true);
+        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true, true);
         assertNumberToken(tokens[0], 2d);
         assertNumberToken(tokens[1], 2d);
         assertOperatorToken(tokens[2], "-", 1, Operator.PRECEDENCE_UNARY_MINUS);
@@ -77,7 +77,7 @@ public class ShuntingYardTest {
     @Test
     public void testShuntingYard6() throws Exception {
         String expression = "2^---+2";
-        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true);
+        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true, true);
         assertNumberToken(tokens[0], 2d);
         assertNumberToken(tokens[1], 2d);
         assertOperatorToken(tokens[2], "+", 1, Operator.PRECEDENCE_UNARY_PLUS);
@@ -109,7 +109,7 @@ public class ShuntingYardTest {
         };
         Map<String, Operator> userOperators = new HashMap<String, Operator>();
         userOperators.put("!", factorial);
-        Token[] tokens = ShuntingYard.convertToRPN(expression, null, userOperators, null, true);
+        Token[] tokens = ShuntingYard.convertToRPN(expression, null, userOperators, null, true, true);
         assertNumberToken(tokens[0], 2d);
         assertNumberToken(tokens[1], 2d);
         assertOperatorToken(tokens[2], "!", 1, Operator.PRECEDENCE_POWER + 1);
@@ -120,7 +120,7 @@ public class ShuntingYardTest {
     @Test
     public void testShuntingYard8() throws Exception {
         String expression = "-3^2";
-        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true);
+        Token[] tokens = ShuntingYard.convertToRPN(expression, null, null, null, true, true);
         assertNumberToken(tokens[0], 3d);
         assertNumberToken(tokens[1], 2d);
         assertOperatorToken(tokens[2], "^", 2, Operator.PRECEDENCE_POWER);
@@ -140,7 +140,7 @@ public class ShuntingYardTest {
         };
         Map<String, Operator> userOperators = new HashMap<String, Operator>();
         userOperators.put("$", reciprocal);
-        Token[] tokens = ShuntingYard.convertToRPN("1$", null, userOperators, null, true);
+        Token[] tokens = ShuntingYard.convertToRPN("1$", null, userOperators, null, true, true);
         assertNumberToken(tokens[0], 1d);
         assertOperatorToken(tokens[1], "$", 1, Operator.PRECEDENCE_DIVISION);
     }

--- a/src/test/java/net/objecthunter/exp4j/tokenizer/TokenizerUnknownTokenOrVariableTest.java
+++ b/src/test/java/net/objecthunter/exp4j/tokenizer/TokenizerUnknownTokenOrVariableTest.java
@@ -95,12 +95,12 @@ public class TokenizerUnknownTokenOrVariableTest {
 	@Test
 	public void testTokenizationOfUnknownVariableWithoutException() throws Exception {
 
-		final Tokenizer tokenizer = new Tokenizer("x + 3", null, null, null, false, false);
+		final Tokenizer tokenizer = new Tokenizer("xiop+3", null, null, null, false, false);
 
 		try {
 			Token token = tokenizer.nextToken(); // x
 			Assert.assertEquals(Token.TOKEN_VARIABLE, token.getType());
-			Assert.assertEquals("x ", ((VariableToken)token).getName() );
+			Assert.assertEquals("xiop", ((VariableToken)token).getName() );
 		} catch (UnknownFunctionOrVariableException e) {
 			Assert.fail("No exception should be thrown!");
 		}
@@ -114,7 +114,7 @@ public class TokenizerUnknownTokenOrVariableTest {
 		try {
 			Token token = tokenizer.nextToken(); // x
 			Assert.assertEquals(Token.TOKEN_VARIABLE, token.getType());
-			Assert.assertEquals("x ", ((VariableToken)token).getName() );
+			Assert.assertEquals("x", ((VariableToken)token).getName() );
 
 			tokenizer.nextToken(); // +
 			tokenizer.nextToken(); // 3
@@ -137,7 +137,7 @@ public class TokenizerUnknownTokenOrVariableTest {
 		try {
 			Token token = tokenizer.nextToken(); // xyz
 			Assert.assertEquals(Token.TOKEN_VARIABLE, token.getType());
-			Assert.assertEquals("xyz ", ((VariableToken)token).getName() );
+			Assert.assertEquals("xyz", ((VariableToken)token).getName() );
 		} catch (UnknownFunctionOrVariableException e) {
 			Assert.fail("No exception should be thrown!");
 		}

--- a/src/test/java/net/objecthunter/exp4j/tokenizer/TokenizerUnknownTokenOrVariableTest.java
+++ b/src/test/java/net/objecthunter/exp4j/tokenizer/TokenizerUnknownTokenOrVariableTest.java
@@ -91,4 +91,95 @@ public class TokenizerUnknownTokenOrVariableTest {
 			Assert.assertEquals("p(1) + 3", e.getExpression());
 		}
 	}
+
+	@Test
+	public void testTokenizationOfUnknownVariableWithoutException() throws Exception {
+
+		final Tokenizer tokenizer = new Tokenizer("x + 3", null, null, null, false, false);
+
+		try {
+			Token token = tokenizer.nextToken(); // x
+			Assert.assertEquals(Token.TOKEN_VARIABLE, token.getType());
+			Assert.assertEquals("x ", ((VariableToken)token).getName() );
+		} catch (UnknownFunctionOrVariableException e) {
+			Assert.fail("No exception should be thrown!");
+		}
+	}
+
+	@Test
+	public void testTokenizationOfUnknownVariableWithoutException2() throws Exception {
+
+		final Tokenizer tokenizer = new Tokenizer("x + 3 + y", null, null, null, false, false);
+
+		try {
+			Token token = tokenizer.nextToken(); // x
+			Assert.assertEquals(Token.TOKEN_VARIABLE, token.getType());
+			Assert.assertEquals("x ", ((VariableToken)token).getName() );
+
+			tokenizer.nextToken(); // +
+			tokenizer.nextToken(); // 3
+			tokenizer.nextToken(); // +
+
+			token = tokenizer.nextToken(); // y
+			Assert.assertEquals(Token.TOKEN_VARIABLE, token.getType());
+			Assert.assertEquals("y", ((VariableToken)token).getName() );
+
+		} catch (UnknownFunctionOrVariableException e) {
+			Assert.fail("No exception should be thrown!");
+		}
+	}
+
+	@Test
+	public void testTokenizationOfUnknownVariableWithoutExceptionAndImplicit() throws Exception {
+
+		final Tokenizer tokenizer = new Tokenizer("xyz + 3", null, null, null, true, false);
+
+		try {
+			Token token = tokenizer.nextToken(); // xyz
+			Assert.assertEquals(Token.TOKEN_VARIABLE, token.getType());
+			Assert.assertEquals("xyz ", ((VariableToken)token).getName() );
+		} catch (UnknownFunctionOrVariableException e) {
+			Assert.fail("No exception should be thrown!");
+		}
+	}
+
+	@Test(expected = UnknownFunctionOrVariableException.class)
+	public void testTokenizationOfUnknownFunctionWithoutException() throws Exception {
+		final Tokenizer tokenizer = new Tokenizer("3 + p(1)", null, null, null, false, false);
+		while (tokenizer.hasNext()) {
+			tokenizer.nextToken();
+		}
+	}
+
+	@Test
+	public void testTokenizationOfUnknownFunction1DetailsWithoutException() throws Exception {
+
+		final Tokenizer tokenizer = new Tokenizer("3 + p(1)", null, null, null, false, false);
+		tokenizer.nextToken(); // 3
+		tokenizer.nextToken(); // +
+
+		try {
+			tokenizer.nextToken(); // p
+			Assert.fail("Function 'p' should be unknown!");
+		} catch (UnknownFunctionOrVariableException e) {
+			Assert.assertEquals("p", e.getToken());
+			Assert.assertEquals(4, e.getPosition());
+			Assert.assertEquals("3 + p(1)", e.getExpression());
+		}
+	}
+
+	@Test
+	public void testTokenizationOfUnknownFunction2DetailsWithoutException() throws Exception {
+
+		final Tokenizer tokenizer = new Tokenizer("p(1) + 3", null, null, null, false, false);
+
+		try {
+			tokenizer.nextToken(); // p
+			Assert.fail("Function 'p' should be unknown!");
+		} catch (UnknownFunctionOrVariableException e) {
+			Assert.assertEquals("p", e.getToken());
+			Assert.assertEquals(0, e.getPosition());
+			Assert.assertEquals("p(1) + 3", e.getExpression());
+		}
+	}
 }


### PR DESCRIPTION
I find that I often have equations with user defined values, and therefore often have missing or incorrect values. I want to be able to provide default values (for example 0) for these parameters, instead of getting an exception and having to rebuild.