### PR TITLE
Issue #88: Fixed multiple function concatenation bug

### DIFF
--- a/src/main/java/net/objecthunter/exp4j/shuntingyard/ShuntingYard.java
+++ b/src/main/java/net/objecthunter/exp4j/shuntingyard/ShuntingYard.java
@@ -51,8 +51,11 @@ public class ShuntingYard {
                 output.add(token);
                 break;
             case Token.TOKEN_FUNCTION:
-                stack.add(token);
-                break;
+				if(!stack.empty() && stack.peek().getType() == Token.TOKEN_FUNCTION) {
+					throw new IllegalArgumentException("Mismatched parentheses detected. Please check the expression");
+				}
+				stack.add(token);
+				break;
             case Token.TOKEN_SEPARATOR:
                 while (!stack.empty() && stack.peek().getType() != Token.TOKEN_PARENTHESES_OPEN) {
                     output.add(stack.pop());

--- a/src/test/java/net/objecthunter/exp4j/shuntingyard/ShuntingYardTest.java
+++ b/src/test/java/net/objecthunter/exp4j/shuntingyard/ShuntingYardTest.java
@@ -145,4 +145,9 @@ public class ShuntingYardTest {
         assertOperatorToken(tokens[1], "$", 1, Operator.PRECEDENCE_DIVISION);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testShuntingYardMultiFunctionConcat() throws Exception {
+        ShuntingYard.convertToRPN("sincos(x)", null, null, null, true);
+    }
+
 }


### PR DESCRIPTION
Possible fix for the concatenating function bug. 

In order to check that the following case does not appear _sincos(x)_ a check is added in the **ShuntingYard** which verifies if 2 function tokens are detected and between them is no other token. This verification will ensure that only _sin(cos(x))_ is valid.