### PR TITLE
Fix bug in array index handling

### DIFF
--- a/src/main/java/net/objecthunter/exp4j/tokenizer/Tokenizer.java
+++ b/src/main/java/net/objecthunter/exp4j/tokenizer/Tokenizer.java
@@ -69,7 +69,10 @@ public class Tokenizer {
     public Token nextToken() {
         char ch = expression[pos];
         while (Character.isWhitespace(ch)) {
-            ch = expression[++pos];
+            if (expression.length <= ++pos) {
+                throw new IllegalArgumentException("Unable to find next token. Only whitespace characters left.");
+            }
+            ch = expression[pos];
         }
         if (Character.isDigit(ch) || ch == '.') {
             if (lastToken != null) {


### PR DESCRIPTION
This fixes an unwrapped ArrayIndexOutOfBoundException in src/main/java/net/objecthunter/exp4j/tokenizer/Tokenizer.java.

If the expression only contains whitespace characters, or if the expression is ended with whitespace characters. It will result in a possible ArrayIndexOutOfBoundException. This is because the while loop for skipping whitespace characters has incorrect stopping criteria. The while loop will keep running until reaching a non-whitespace character; if the remaining expression only contains whitespace, the loop will not stop at the end of the expression array and the ++pos index will be out of bound in the next iteration.

This PR adds a conditional checking to ensure an exception is thrown if nextToken method is called and only whitespace characters left in the expression to ensure the pos index used in the while loop will not be out of bound.

We found this bug using fuzzing by way of OSS-Fuzz, where we recently integrated exp4j ([google/oss-fuzz#10699](https://github.com/google/oss-fuzz/pull/10699)). OSS-Fuzz is a free service run by Google for fuzzing important open source software. If you'd like to know more about this then I'm happy to go into detail and also set up things so you can receive emails and detailed reports when bugs are found.